### PR TITLE
Add tests subdir layout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,10 @@ There are three options:
   source files.  Test files are prefixed with ``test_``.  For example, the
   test file for the source file ``foo/bar.py`` is called
   ``foo/test_bar.py``.  Use this setting when testing Django apps.
+* **tests-subdir**: Put test files next to their related source files,
+  in a subdirectory named ``tests``. Test files are prefixed with ``test_``.
+  For example, the test file for the source file ``foo/bar.py`` is called
+  ``foo/tests/test_bar.py``.
 * **follow-hierarchy**: Put all the test files in a separate test
   directory (specified by ``PyUnitTestsRoot``), but keep the same
   directory hierarchy as used in the source directory.
@@ -137,7 +141,7 @@ The plugin supports setting of the following variables:
 | ``PyUnitTestsRoot``           | The relative location where all tests live.    | directory spec            | "tests"                           |
 +-------------------------------+------------------------------------------------+---------------------------+-----------------------------------+
 | ``PyUnitTestsStructure``      | Specifies how you wish to organise your tests. | flat, follow-hierarchy,   | "follow-hierarchy"                |
-|                               |                                                | side-by-side              |                                   |
+|                               |                                                | side-by-side, tests-subdir|                                   |
 +-------------------------------+------------------------------------------------+---------------------------+-----------------------------------+
 | ``PyUnitTestsSplitWindow``    | Specifies where test files should be opened,   | left, right, top, bottom, | "right"                           |
 |                               | when oopened next to the source file. When set | no                        |                                   |

--- a/ftplugin/python_pyunit.vim
+++ b/ftplugin/python_pyunit.vim
@@ -264,6 +264,37 @@ class SideBySideLayout(BaseTestLayout):
         return [self.glue_parts(parts)]
 
 
+class TestsSubdirLayout(BaseTestLayout):
+    SUBDIR_NAME = 'tests'
+
+    def is_test_file(self, some_file):
+        some_file = self.relatize(some_file)
+        parts = self.break_down(some_file)
+        if len(parts) >= 2:
+            filepart = parts[-1]
+            return filepart.startswith(self.prefix) and parts[-2] == self.SUBDIR_NAME
+        else:
+            return False
+
+    def get_test_file(self, source_file):
+        source_file_path = self.relatize(source_file)
+        parts = self.break_down(source_file_path)
+        source_file_name = parts[-1]
+        parts[-1] = self.SUBDIR_NAME
+        parts.append(self.prefix + source_file_name)
+        return self.glue_parts(parts)
+
+    def get_source_candidates(self, test_file):
+        test_file = self.relatize(test_file)
+        parts = self.break_down(test_file)
+        filepart = parts[-1]
+        if filepart.startswith(self.prefix) and parts[-2] == self.SUBDIR_NAME:
+            parts.pop(-2)
+        else:
+            raise RuntimeError("Not a test file.")
+        parts[-1] = filepart[len(self.prefix):]
+        return [self.glue_parts(parts)]
+
 class FlatLayout(BaseTestLayout):
     def is_test_file(self, some_file):
         some_file = self.relatize(some_file)
@@ -383,6 +414,7 @@ def get_implementing_class():
         'flat': FlatLayout,
         'follow-hierarchy': FollowHierarchyLayout,
         'side-by-side': SideBySideLayout,
+        'tests-subdir': TestsSubdirLayout,
         'nose': NoseLayout,
     }
     test_layout = vim.eval('g:PyUnitTestsStructure')

--- a/src/python_unittests.py
+++ b/src/python_unittests.py
@@ -154,6 +154,37 @@ class SideBySideLayout(BaseTestLayout):
         return [self.glue_parts(parts)]
 
 
+class TestsSubdirLayout(BaseTestLayout):
+    SUBDIR_NAME = 'tests'
+
+    def is_test_file(self, some_file):
+        some_file = self.relatize(some_file)
+        parts = self.break_down(some_file)
+        if len(parts) >= 2:
+            filepart = parts[-1]
+            return filepart.startswith(self.prefix) and parts[-2] == self.SUBDIR_NAME
+        else:
+            return False
+
+    def get_test_file(self, source_file):
+        source_file_path = self.relatize(source_file)
+        parts = self.break_down(source_file_path)
+        source_file_name = parts[-1]
+        parts[-1] = self.SUBDIR_NAME
+        parts.append(self.prefix + source_file_name)
+        return self.glue_parts(parts)
+
+    def get_source_candidates(self, test_file):
+        test_file = self.relatize(test_file)
+        parts = self.break_down(test_file)
+        filepart = parts[-1]
+        if filepart.startswith(self.prefix) and parts[-2] == self.SUBDIR_NAME:
+            parts.pop(-2)
+        else:
+            raise RuntimeError("Not a test file.")
+        parts[-1] = filepart[len(self.prefix):]
+        return [self.glue_parts(parts)]
+
 class FlatLayout(BaseTestLayout):
     def is_test_file(self, some_file):
         some_file = self.relatize(some_file)
@@ -273,6 +304,7 @@ def get_implementing_class():
         'flat': FlatLayout,
         'follow-hierarchy': FollowHierarchyLayout,
         'side-by-side': SideBySideLayout,
+        'tests-subdir': TestsSubdirLayout,
         'nose': NoseLayout,
     }
     test_layout = vim.eval('g:PyUnitTestsStructure')


### PR DESCRIPTION
Hi mate,
At my workplace we have a convention of placing test files in a subdir named 'tests' next to the source file.
I couldn't find a suitable layout in the plugin, so I created one.

Out of this pull request's updated Readme:

> - **tests-subdir**: Put test files next to their related source files,
>   in a subdirectory named `tests`. Test files are prefixed with `test_`.
>   For example, the test file for the source file `foo/bar.py` is called
>   `foo/tests/test_bar.py`.

Unit tests and updated Readme included as well.

Thanks,
Roy
